### PR TITLE
Fetch all Awattar data until the end of next day.

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles
 arrow
 configupdater
 fastapi

--- a/Backend/src/awattprice/awattar.py
+++ b/Backend/src/awattprice/awattar.py
@@ -24,11 +24,17 @@ from .defaults import Region
 from .utils import before_log
 
 
-async def get(*, config: Box, region: Region) -> Optional[List[Any]]:
+async def get(
+        *,
+        config: Box,
+        region: Region,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+) -> Optional[List[Any]]:
     """Fetch and write Awattar data."""
     start_ts = arrow.utcnow()
     try:
-        data = await get_data(config=config, region=region)
+        data = await get_data(config=config, region=region, start=start, end=end)
     except Exception as e:
         log.warning("Could not fetch Awattar data: {}.".format(str(e)))
     else:
@@ -66,6 +72,7 @@ async def get_data(
         url = endpoint.format("")
     timeout = 10.0
 
+    log.debug(f"Awattar URL: {url}")
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(url, timeout=timeout)

--- a/Backend/src/awattprice/poll.py
+++ b/Backend/src/awattprice/poll.py
@@ -120,10 +120,10 @@ async def get_data(config: Box, region: Optional[Region] = None, force: bool = F
                 must_write_data = True
                 data.prices.append(entry)
         if must_write_data:
-            data.meta.update_ts = arrow.utcnow().timestamp
+            data.meta.update_ts = now.timestamp
     elif fetched_data:
         data = Box({"prices": [], "meta": {}}, box_dots=True)
-        data.meta["update_ts"] = arrow.utcnow().timestamp
+        data.meta["update_ts"] = now.timestamp
         for entry in fetched_data:
             entry = transform_entry(entry)
             if entry:

--- a/Backend/src/awattprice/poll.py
+++ b/Backend/src/awattprice/poll.py
@@ -80,7 +80,7 @@ async def get_data(config: Box, region: Optional[Region] = None, force: bool = F
         region = Region.DE
     # 1) Read the data file.
     file_path = Path(config.file_location.data_dir).expanduser() / Path(f"awattar-data-{region.name.lower()}.json")
-    data = read_data(file_path=file_path)
+    data = await read_data(file_path=file_path)
     fetched_data = None
     need_update = True
     last_update = 0

--- a/Backend/src/awattprice/poll.py
+++ b/Backend/src/awattprice/poll.py
@@ -102,7 +102,7 @@ async def get_data(config: Box, region: Optional[Region] = None, force: bool = F
     if need_update or force:
         # By default the Awattar API returns data for the next 24h. It can provide
         # data until tomorrow midnight. Let's ask for that. Further, set the start
-        # time to the last full hour. The Awattar API expects microsecond time stamps.
+        # time to the last full hour. The Awattar API expects microsecond timestamps.
         start = now.replace(minute=0, second=0, microsecond=0).timestamp * TIME_CORRECT
         end = now.shift(days=+2).replace(hour=0, minute=0, second=0, microsecond=0).timestamp * TIME_CORRECT
         future = awattar_read_task(config=config, region=region, start=start, end=end)


### PR DESCRIPTION
 The standard query to the Awattar API returns data for the next 24 hours. However, the API knows the data until the end of the next day. Hence, we now set the time frame we request the data for.

Testing:
>mypy awattprice/*py
Success: no issues found in 6 source files